### PR TITLE
fix: remove leading "/" in `get_public_url` methods

### DIFF
--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -72,7 +72,7 @@ class AsyncBucketActionsMixin:
             file path, including the path and file name. For example `folder/image.png`.
         """
         _path = self._get_final_path(path)
-        return f"{self._client.base_url}/object/public/{_path}"
+        return f"{self._client.base_url}object/public/{_path}"
 
     async def move(self, from_path: str, to_path: str) -> dict[str, str]:
         """

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -72,7 +72,7 @@ class SyncBucketActionsMixin:
             file path, including the path and file name. For example `folder/image.png`.
         """
         _path = self._get_final_path(path)
-        return f"{self._client.base_url}/object/public/{_path}"
+        return f"{self._client.base_url}object/public/{_path}"
 
     def move(self, from_path: str, to_path: str) -> dict[str, str]:
         """


### PR DESCRIPTION
When using the `get_public_url` methods, you get the following responses:

```
https://SUPABASE_ID.supabase.co/storage/v1//object/public/BUCKET/FILE
```

Notice the double slash between the `v1` and the `object` substrings in the path.

Even though the URL works---as captured by the tests--it is a non-consistent way of rendering the URL's subpaths.

This commit sets it so that all the sub-paths inside the public URL have a single slash.