### PR TITLE
Justinbarak patch 1

### DIFF
--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -72,7 +72,7 @@ class AsyncBucketActionsMixin:
             file path, including the path and file name. For example `folder/image.png`.
         """
         _path = self._get_final_path(path)
-        return f"{self._client.base_url}/object/public/{_path}"
+        return f"{self._client.base_url}object/public/{_path}"
 
     async def move(self, from_path: str, to_path: str) -> dict[str, str]:
         """

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -72,7 +72,7 @@ class SyncBucketActionsMixin:
             file path, including the path and file name. For example `folder/image.png`.
         """
         _path = self._get_final_path(path)
-        return f"{self._client.base_url}/object/public/{_path}"
+        return f"{self._client.base_url}object/public/{_path}"
 
     def move(self, from_path: str, to_path: str) -> dict[str, str]:
         """


### PR DESCRIPTION
Fix double `/` referenced in [issue #261](https://github.com/supabase-community/supabase-py/issues/261#issue-1353071612). Fixed both in async and sync codebases.