### PR TITLE
fix: added missing types

### DIFF
--- a/storage3/types.py
+++ b/storage3/types.py
@@ -18,6 +18,8 @@ class BaseBucket:
     public: bool
     created_at: datetime
     updated_at: datetime
+    file_size_limit: int
+    allowed_mime_types: str
 
     def __post_init__(self) -> None:
         # created_at and updated_at are returned by the API as ISO timestamps


### PR DESCRIPTION
An update to the [supabase/storage-api](https://github.com/supabase/storage-api/pull/277) introduced new types `file_size_limit` and `allowed_mime_types`

Pr fixes error:
```
!!! TypeError: __init__() got an unexpected keyword argument 'file_size_limit'
```