### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = "MIT"
 name = "storage3"
 readme = "README.md"
 repository = "https://github.com/supabase-community/storage-py"
-version = "0.5.1"
+version = "0.5.2"
 
 [tool.poetry.dependencies]
 httpx = "^0.23"

--- a/storage3/utils.py
+++ b/storage3/utils.py
@@ -1,7 +1,7 @@
 from httpx import AsyncClient as AsyncClient  # noqa: F401
 from httpx import Client as BaseClient
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 
 class SyncClient(BaseClient):


### PR DESCRIPTION
branch name is incorrect, version is actually 0.5.2