### PR TITLE
Fix bad typing on upload functions

### DIFF
--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -164,7 +164,8 @@ class AsyncBucketActionsMixin:
         """
         extra_options = options or {}
         extra_headers = {"Content-Type": "application/json"}
-        body = {**DEFAULT_SEARCH_OPTIONS, **extra_options, "prefix": path or ""}
+        body = {**DEFAULT_SEARCH_OPTIONS, **
+                extra_options, "prefix": path or ""}
         response = await self._request(
             "POST",
             f"/object/list/{self.id}",
@@ -183,7 +184,8 @@ class AsyncBucketActionsMixin:
             The file path to be downloaded, including the path and file name. For example `folder/image.png`.
         """
         render_path = (
-            "render/image/authenticated" if options.get("transform") else "object"
+            "render/image/authenticated" if options.get(
+                "transform") else "object"
         )
         transformation_query = urllib.parse.urlencode(options)
         query_string = f"?{transformation_query}" if transformation_query else ""
@@ -196,7 +198,7 @@ class AsyncBucketActionsMixin:
         return response.content
 
     async def upload(
-        self, path: str, file: Union[str, Path], file_options: Optional[dict] = None
+        self, path: str, file: Union[BufferedReader, bytes, FileIO, str, Path], file_options: Optional[dict] = None
     ) -> Response:
         """
         Uploads a file to an existing bucket.
@@ -213,7 +215,8 @@ class AsyncBucketActionsMixin:
         """
         if file_options is None:
             file_options = {}
-        headers = {**self._client.headers, **DEFAULT_FILE_OPTIONS, **file_options}
+        headers = {**self._client.headers, **
+                   DEFAULT_FILE_OPTIONS, **file_options}
         filename = path.rsplit("/", maxsplit=1)[-1]
 
         if (
@@ -225,7 +228,8 @@ class AsyncBucketActionsMixin:
             files = {"file": (filename, file, headers.pop("content-type"))}
         else:
             # str or pathlib.path received
-            files = {"file": (filename, open(file, "rb"), headers.pop("content-type"))}
+            files = {"file": (filename, open(file, "rb"),
+                              headers.pop("content-type"))}
 
         _path = self._get_final_path(path)
 

--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -164,8 +164,11 @@ class AsyncBucketActionsMixin:
         """
         extra_options = options or {}
         extra_headers = {"Content-Type": "application/json"}
-        body = {**DEFAULT_SEARCH_OPTIONS, **
-                extra_options, "prefix": path or ""}
+        body = {
+            **DEFAULT_SEARCH_OPTIONS,
+            **extra_options,
+            "prefix": path or "",
+        }
         response = await self._request(
             "POST",
             f"/object/list/{self.id}",
@@ -184,8 +187,7 @@ class AsyncBucketActionsMixin:
             The file path to be downloaded, including the path and file name. For example `folder/image.png`.
         """
         render_path = (
-            "render/image/authenticated" if options.get(
-                "transform") else "object"
+            "render/image/authenticated" if options.get("transform") else "object"
         )
         transformation_query = urllib.parse.urlencode(options)
         query_string = f"?{transformation_query}" if transformation_query else ""
@@ -198,7 +200,10 @@ class AsyncBucketActionsMixin:
         return response.content
 
     async def upload(
-        self, path: str, file: Union[BufferedReader, bytes, FileIO, str, Path], file_options: Optional[dict] = None
+        self,
+        path: str,
+        file: Union[BufferedReader, bytes, FileIO, str, Path],
+        file_options: Optional[dict] = None,
     ) -> Response:
         """
         Uploads a file to an existing bucket.
@@ -215,8 +220,11 @@ class AsyncBucketActionsMixin:
         """
         if file_options is None:
             file_options = {}
-        headers = {**self._client.headers, **
-                   DEFAULT_FILE_OPTIONS, **file_options}
+        headers = {
+            **self._client.headers,
+            **DEFAULT_FILE_OPTIONS,
+            **file_options,
+        }
         filename = path.rsplit("/", maxsplit=1)[-1]
 
         if (
@@ -228,8 +236,13 @@ class AsyncBucketActionsMixin:
             files = {"file": (filename, file, headers.pop("content-type"))}
         else:
             # str or pathlib.path received
-            files = {"file": (filename, open(file, "rb"),
-                              headers.pop("content-type"))}
+            files = {
+                "file": (
+                    filename,
+                    open(file, "rb"),
+                    headers.pop("content-type"),
+                )
+            }
 
         _path = self._get_final_path(path)
 

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -164,8 +164,7 @@ class SyncBucketActionsMixin:
         """
         extra_options = options or {}
         extra_headers = {"Content-Type": "application/json"}
-        body = {**DEFAULT_SEARCH_OPTIONS, **
-                extra_options, "prefix": path or ""}
+        body = {**DEFAULT_SEARCH_OPTIONS, **extra_options, "prefix": path or ""}
         response = self._request(
             "POST",
             f"/object/list/{self.id}",
@@ -184,8 +183,7 @@ class SyncBucketActionsMixin:
             The file path to be downloaded, including the path and file name. For example `folder/image.png`.
         """
         render_path = (
-            "render/image/authenticated" if options.get(
-                "transform") else "object"
+            "render/image/authenticated" if options.get("transform") else "object"
         )
         transformation_query = urllib.parse.urlencode(options)
         query_string = f"?{transformation_query}" if transformation_query else ""
@@ -198,7 +196,10 @@ class SyncBucketActionsMixin:
         return response.content
 
     def upload(
-        self, path: str, file: Union[BufferedReader, bytes, FileIO, str, Path], file_options: Optional[dict] = None
+        self,
+        path: str,
+        file: Union[BufferedReader, bytes, FileIO, str, Path],
+        file_options: Optional[dict] = None,
     ) -> Response:
         """
         Uploads a file to an existing bucket.
@@ -215,8 +216,7 @@ class SyncBucketActionsMixin:
         """
         if file_options is None:
             file_options = {}
-        headers = {**self._client.headers, **
-                   DEFAULT_FILE_OPTIONS, **file_options}
+        headers = {**self._client.headers, **DEFAULT_FILE_OPTIONS, **file_options}
         filename = path.rsplit("/", maxsplit=1)[-1]
 
         if (
@@ -228,8 +228,7 @@ class SyncBucketActionsMixin:
             files = {"file": (filename, file, headers.pop("content-type"))}
         else:
             # str or pathlib.path received
-            files = {"file": (filename, open(file, "rb"),
-                              headers.pop("content-type"))}
+            files = {"file": (filename, open(file, "rb"), headers.pop("content-type"))}
 
         _path = self._get_final_path(path)
 

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -164,7 +164,8 @@ class SyncBucketActionsMixin:
         """
         extra_options = options or {}
         extra_headers = {"Content-Type": "application/json"}
-        body = {**DEFAULT_SEARCH_OPTIONS, **extra_options, "prefix": path or ""}
+        body = {**DEFAULT_SEARCH_OPTIONS, **
+                extra_options, "prefix": path or ""}
         response = self._request(
             "POST",
             f"/object/list/{self.id}",
@@ -183,7 +184,8 @@ class SyncBucketActionsMixin:
             The file path to be downloaded, including the path and file name. For example `folder/image.png`.
         """
         render_path = (
-            "render/image/authenticated" if options.get("transform") else "object"
+            "render/image/authenticated" if options.get(
+                "transform") else "object"
         )
         transformation_query = urllib.parse.urlencode(options)
         query_string = f"?{transformation_query}" if transformation_query else ""
@@ -196,7 +198,7 @@ class SyncBucketActionsMixin:
         return response.content
 
     def upload(
-        self, path: str, file: Union[str, Path], file_options: Optional[dict] = None
+        self, path: str, file: Union[BufferedReader, bytes, FileIO, str, Path], file_options: Optional[dict] = None
     ) -> Response:
         """
         Uploads a file to an existing bucket.
@@ -213,7 +215,8 @@ class SyncBucketActionsMixin:
         """
         if file_options is None:
             file_options = {}
-        headers = {**self._client.headers, **DEFAULT_FILE_OPTIONS, **file_options}
+        headers = {**self._client.headers, **
+                   DEFAULT_FILE_OPTIONS, **file_options}
         filename = path.rsplit("/", maxsplit=1)[-1]
 
         if (
@@ -225,7 +228,8 @@ class SyncBucketActionsMixin:
             files = {"file": (filename, file, headers.pop("content-type"))}
         else:
             # str or pathlib.path received
-            files = {"file": (filename, open(file, "rb"), headers.pop("content-type"))}
+            files = {"file": (filename, open(file, "rb"),
+                              headers.pop("content-type"))}
 
         _path = self._get_final_path(path)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

It simply update the function prototype of `upload` to type correctly the file argument

## What is the current behavior?

The upload function implements the management of Bytes/IO-like buffers, but the types of the functions doesn't allow their use.
