### PR TITLE
feat: bucket level file controls and an update_bucket method

### DIFF
--- a/storage3/_sync/bucket.py
+++ b/storage3/_sync/bucket.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from httpx import HTTPError, Response
 
-from ..types import RequestMethod
+from ..types import CreateOrUpdateBucketOptions, RequestMethod
 from ..utils import StorageException, SyncClient
 from .file_api import SyncBucket
 
@@ -52,7 +52,10 @@ class SyncStorageBucketAPI:
         return SyncBucket(**json, _client=self._client)
 
     def create_bucket(
-        self, id: str, name: Optional[str] = None, public: bool = False
+        self,
+        id: str,
+        name: Optional[str] = None,
+        options: Optional[CreateOrUpdateBucketOptions] = None,
     ) -> dict[str, str]:
         """Creates a new storage bucket.
 
@@ -62,14 +65,35 @@ class SyncStorageBucketAPI:
             A unique identifier for the bucket you are creating.
         name
             A name for the bucket you are creating. If not passed, the id is used as the name as well.
-        public
-            Whether the bucket you are creating should be publicly accessible. Defaults to False.
+        options
+            Extra options to send while creating the bucket. Valid options are `public`, `file_size_limit` and
+            `allowed_mime_types`.
         """
+        json: dict[str, Any] = {"id": id, "name": name or id}
+        if options:
+            json.update(**options)
         res = self._request(
             "POST",
             "/bucket",
-            json={"id": id, "name": name or id, "public": public},
+            json=json,
         )
+        return res.json()
+
+    def update_bucket(
+        self, id: str, options: CreateOrUpdateBucketOptions
+    ) -> dict[str, str]:
+        """Update a storage bucket.
+
+        Parameters
+        ----------
+        id
+            The unique identifier of the bucket you would like to update.
+        options
+            The properties you want to update. Valid options are `public`, `file_size_limit` and
+            `allowed_mime_types`.
+        """
+        json = {"id": id, "name": id, **options}
+        res = self._request("PUT", f"/bucket/{id}", json=json)
         return res.json()
 
     def empty_bucket(self, id: str) -> dict[str, str]:

--- a/storage3/types.py
+++ b/storage3/types.py
@@ -19,7 +19,7 @@ class BaseBucket:
     created_at: datetime
     updated_at: datetime
     file_size_limit: Optional[int]
-    allowed_mime_types: Optional[int]
+    allowed_mime_types: Optional[list[str]]
 
     def __post_init__(self) -> None:
         # created_at and updated_at are returned by the API as ISO timestamps
@@ -32,6 +32,12 @@ class BaseBucket:
 class _sortByType(TypedDict):
     column: str
     order: Literal["asc", "desc"]
+
+
+class CreateOrUpdateBucketOptions(TypedDict, total=False):
+    public: bool
+    file_size_limit: int
+    allowed_mime_types: list[str]
 
 
 class ListBucketFilesOptions(TypedDict):

--- a/storage3/types.py
+++ b/storage3/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional, Union

--- a/tests/_async/test_client.py
+++ b/tests/_async/test_client.py
@@ -89,7 +89,7 @@ async def public_bucket(
     global temp_test_buckets_ids
     temp_test_buckets_ids.append(bucket_id)
 
-    await storage.create_bucket(id=bucket_id, public=True)
+    await storage.create_bucket(id=bucket_id, options={"public": True})
 
     yield bucket_id
 

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -87,7 +87,7 @@ def public_bucket(storage: SyncStorageClient, uuid_factory: Callable[[], str]) -
     global temp_test_buckets_ids
     temp_test_buckets_ids.append(bucket_id)
 
-    storage.create_bucket(id=bucket_id, public=True)
+    storage.create_bucket(id=bucket_id, options={"public": True})
 
     yield bucket_id
 


### PR DESCRIPTION
As part of #84 , this PR adds:
- options to set `file_size_limit` and `allowed_mime_types` while creating a bucket
- a new `update_bucket` method that can set these attributes to existing buckets

Corresponding storage-js PR: supabase/storage-js#151