### PR TITLE
Fix semantic releaase workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,6 @@ jobs:
         if: steps.release.outputs.released == 'true'
 
       - name: Python Semantic Release
-        uses: python-semantic-release/upload-to-gh-release@master
+        uses: python-semantic-release/upload-to-gh-release@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for semantic release as it's currently borked.

## What is the current behavior?

Python semantic release no longer has a master branch so the CI/CD breaks

## What is the new behavior?

I've pointed to the main branch of python semantic release and CI/CD should be fixed now

## Additional context

Add any other context or screenshots.
