### PR TITLE
fix: make download key optional

### DIFF
--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -187,7 +187,7 @@ class AsyncBucketActionsMixin:
         """
         json = {"paths": paths, "expiresIn": str(expires_in)}
         if options.get("download"):
-            json.update({"download": options["download"]})
+            json.update({"download": options.get("download")})
 
         response = await self._request(
             "POST",

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -187,7 +187,7 @@ class SyncBucketActionsMixin:
         """
         json = {"paths": paths, "expiresIn": str(expires_in)}
         if options.get("download"):
-            json.update({"download": options["download"]})
+            json.update({"download": options.get("download")})
 
         response = self._request(
             "POST",

--- a/storage3/types.py
+++ b/storage3/types.py
@@ -67,7 +67,7 @@ class URLOptions(TypedDict, total=False):
     transform: TransformOptions
 
 
-class CreateSignedURLsOptions(TypedDict):
+class CreateSignedURLsOptions(TypedDict, total=False):
     download: Union[str, bool]
 
 


### PR DESCRIPTION
Make "download" key optional for create_signed_url; without this passing {} as the options argument would make the static type-checker complain
