### PR TITLE
fix: send cache-control as form data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: '^.*\.(md|MD)$'
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.0.1

--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -16,7 +16,7 @@ Options
 
 .. autotypeddict:: storage3.types.TransformOptions
 
-.. autotypeddict:: storage3.types.CreateSignedURLOptions
+.. autotypeddict:: storage3.types.URLOptions
 
 .. autotypeddict:: storage3.types.CreateSignedURLsOptions
 

--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -279,7 +279,7 @@ class AsyncBucketActionsMixin:
         )
         return res.json()
 
-    async def remove(self, paths: list) -> list[dict[str, any]]:
+    async def remove(self, paths: list) -> list[dict[str, Any]]:
         """
         Deletes files within the same bucket
 

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -279,7 +279,7 @@ class SyncBucketActionsMixin:
         )
         return res.json()
 
-    def remove(self, paths: list) -> list[dict[str, any]]:
+    def remove(self, paths: list) -> list[dict[str, Any]]:
         """
         Deletes files within the same bucket
 


### PR DESCRIPTION
Previously, user set "cache control" was only being passed as a header. This resulted in the cache-control not being properly set after upload.
This PR sends it also as part of form data like [storage-js does](https://github.com/supabase/storage-js/blob/fa44be8156295ba6320ffeff96bdf91016536a46/src/packages/StorageFileApi.ts#L89)

Note: ~~looks like pre-commit isn't happy with the changelog again~~ fixed