### PR TITLE
Make get_public_url sync

### DIFF
--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -198,7 +198,7 @@ class AsyncBucketActionsMixin:
             ] = f"{self._client.base_url}{cast(str, item['signedURL']).lstrip('/')}"
         return data
 
-    async def get_public_url(self, path: str, options: URLOptions = {}) -> str:
+    def get_public_url(self, path: str, options: URLOptions = {}) -> str:
         """
         Parameters
         ----------


### PR DESCRIPTION
## What kind of change does this PR introduce?

Simplify get_public_url signature by removing async

## What is the current behavior?

It's async

## What is the new behavior?

It's not async

## Additional context

There is no need to since there is nothing to await. It makes the consumers more complicated and it looks like it will have a side effect which it does not.