### PR TITLE
Add upsert option to upload/update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
                 ]
 
     - repo: https://github.com/myint/autoflake.git
-      rev: v1.4
+      rev: v2.3.0
       hooks:
           - id: autoflake
             args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,53 +1,53 @@
 exclude: '^.*\.(md|MD)$'
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
-    hooks:
-      - id: trailing-whitespace
-      - id: check-added-large-files
-      - id: end-of-file-fixer
-      - id: mixed-line-ending
-        args: ["--fix=lf"]
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.0.1
+      hooks:
+          - id: trailing-whitespace
+          - id: check-added-large-files
+          - id: end-of-file-fixer
+          - id: mixed-line-ending
+            args: ["--fix=lf"]
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args:
-          [
-            "--profile",
-            "black",
-            "--multi-line=3",
-            "--trailing-comma",
-            "--force-grid-wrap=0",
-            "--use-parentheses",
-            "--line-width=88",
-          ]
+    - repo: https://github.com/pycqa/isort
+      rev: 5.12.0
+      hooks:
+          - id: isort
+            args:
+                [
+                    "--profile",
+                    "black",
+                    "--multi-line=3",
+                    "--trailing-comma",
+                    "--force-grid-wrap=0",
+                    "--use-parentheses",
+                    "--line-width=88",
+                ]
 
-  - repo: https://github.com/myint/autoflake.git
-    rev: v2.3.0
-    hooks:
-      - id: autoflake
-        args:
-          [
-            "--in-place",
-            "--remove-all-unused-imports",
-            "--ignore-init-module-imports",
-          ]
+    - repo: https://github.com/myint/autoflake.git
+      rev: v1.4
+      hooks:
+          - id: autoflake
+            args:
+                [
+                    "--in-place",
+                    "--remove-all-unused-imports",
+                    "--ignore-init-module-imports",
+                ]
 
-  - repo: https://github.com/psf/black
-    rev: "23.3.0"
-    hooks:
-      - id: black
+    - repo: https://github.com/psf/black
+      rev: "23.3.0"
+      hooks:
+          - id: black
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
-    hooks:
-      - id: pyupgrade
-        args: ["--py37-plus", "--keep-runtime-typing"]
+    - repo: https://github.com/asottile/pyupgrade
+      rev: v2.29.1
+      hooks:
+          - id: pyupgrade
+            args: ["--py37-plus", "--keep-runtime-typing"]
 
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.20.0
-    hooks:
-      - id: commitizen
-        stages: [commit-msg]
+    - repo: https://github.com/commitizen-tools/commitizen
+      rev: v2.20.0
+      hooks:
+          - id: commitizen
+            stages: [commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,53 +1,53 @@
 exclude: '^.*\.(md|MD)$'
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.0.1
-      hooks:
-          - id: trailing-whitespace
-          - id: check-added-large-files
-          - id: end-of-file-fixer
-          - id: mixed-line-ending
-            args: ["--fix=lf"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
 
-    - repo: https://github.com/pycqa/isort
-      rev: 5.12.0
-      hooks:
-          - id: isort
-            args:
-                [
-                    "--profile",
-                    "black",
-                    "--multi-line=3",
-                    "--trailing-comma",
-                    "--force-grid-wrap=0",
-                    "--use-parentheses",
-                    "--line-width=88",
-                ]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args:
+          [
+            "--profile",
+            "black",
+            "--multi-line=3",
+            "--trailing-comma",
+            "--force-grid-wrap=0",
+            "--use-parentheses",
+            "--line-width=88",
+          ]
 
-    - repo: https://github.com/myint/autoflake.git
-      rev: v1.4
-      hooks:
-          - id: autoflake
-            args:
-                [
-                    "--in-place",
-                    "--remove-all-unused-imports",
-                    "--ignore-init-module-imports",
-                ]
+  - repo: https://github.com/myint/autoflake.git
+    rev: v2.3.0
+    hooks:
+      - id: autoflake
+        args:
+          [
+            "--in-place",
+            "--remove-all-unused-imports",
+            "--ignore-init-module-imports",
+          ]
 
-    - repo: https://github.com/psf/black
-      rev: "23.3.0"
-      hooks:
-          - id: black
+  - repo: https://github.com/psf/black
+    rev: "23.3.0"
+    hooks:
+      - id: black
 
-    - repo: https://github.com/asottile/pyupgrade
-      rev: v2.29.1
-      hooks:
-          - id: pyupgrade
-            args: ["--py37-plus", "--keep-runtime-typing"]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.1
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus", "--keep-runtime-typing"]
 
-    - repo: https://github.com/commitizen-tools/commitizen
-      rev: v2.20.0
-      hooks:
-          - id: commitizen
-            stages: [commit-msg]
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v2.20.0
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]

--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -111,10 +111,6 @@ class AsyncBucketActionsMixin:
         if cache_control:
             file_options["cache-control"] = f"max-age={cache_control}"
             _data = {"cacheControl": cache_control}
-        if file_options.get("upsert"):
-            file_options.update({"x-upsert": file_options.get("upsert")})
-            del file_options["upsert"]
-
         headers = {
             **self._client.headers,
             **DEFAULT_FILE_OPTIONS,
@@ -381,6 +377,11 @@ class AsyncBucketActionsMixin:
             **DEFAULT_FILE_OPTIONS,
             **file_options,
         }
+
+        # Only include x-upsert on a POST method
+        if method != "POST":
+            del headers["x-upsert"]
+
         filename = path.rsplit("/", maxsplit=1)[-1]
 
         if cache_control:

--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -111,6 +111,10 @@ class AsyncBucketActionsMixin:
         if cache_control:
             file_options["cache-control"] = f"max-age={cache_control}"
             _data = {"cacheControl": cache_control}
+        if file_options.get("upsert"):
+            file_options.update({"x-upsert": file_options.get("upsert")})
+            del file_options["upsert"]
+
         headers = {
             **self._client.headers,
             **DEFAULT_FILE_OPTIONS,
@@ -368,6 +372,9 @@ class AsyncBucketActionsMixin:
             file_options = {}
         cache_control = file_options.get("cache-control")
         _data = {}
+        if file_options.get("upsert"):
+            file_options.update({"x-upsert": file_options.get("upsert")})
+            del file_options["upsert"]
 
         headers = {
             **self._client.headers,

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -111,10 +111,6 @@ class SyncBucketActionsMixin:
         if cache_control:
             file_options["cache-control"] = f"max-age={cache_control}"
             _data = {"cacheControl": cache_control}
-        if file_options.get("upsert"):
-            file_options.update({"x-upsert": file_options.get("upsert")})
-            del file_options["upsert"]
-
         headers = {
             **self._client.headers,
             **DEFAULT_FILE_OPTIONS,
@@ -370,9 +366,6 @@ class SyncBucketActionsMixin:
             file_options = {}
         cache_control = file_options.get("cache-control")
         _data = {}
-        if file_options.get("upsert"):
-            file_options.update({"x-upsert": file_options.get("upsert")})
-            del file_options["upsert"]
 
         headers = {
             **self._client.headers,

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -111,6 +111,10 @@ class SyncBucketActionsMixin:
         if cache_control:
             file_options["cache-control"] = f"max-age={cache_control}"
             _data = {"cacheControl": cache_control}
+        if file_options.get("upsert"):
+            file_options.update({"x-upsert": file_options.get("upsert")})
+            del file_options["upsert"]
+
         headers = {
             **self._client.headers,
             **DEFAULT_FILE_OPTIONS,
@@ -366,6 +370,9 @@ class SyncBucketActionsMixin:
             file_options = {}
         cache_control = file_options.get("cache-control")
         _data = {}
+        if file_options.get("upsert"):
+            file_options.update({"x-upsert": file_options.get("upsert")})
+            del file_options["upsert"]
 
         headers = {
             **self._client.headers,

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -111,10 +111,6 @@ class SyncBucketActionsMixin:
         if cache_control:
             file_options["cache-control"] = f"max-age={cache_control}"
             _data = {"cacheControl": cache_control}
-        if file_options.get("upsert"):
-            file_options.update({"x-upsert": file_options.get("upsert")})
-            del file_options["upsert"]
-
         headers = {
             **self._client.headers,
             **DEFAULT_FILE_OPTIONS,
@@ -379,6 +375,11 @@ class SyncBucketActionsMixin:
             **DEFAULT_FILE_OPTIONS,
             **file_options,
         }
+
+        # Only include x-upsert on a POST method
+        if method != "POST":
+            del headers["x-upsert"]
+
         filename = path.rsplit("/", maxsplit=1)[-1]
 
         if cache_control:

--- a/storage3/types.py
+++ b/storage3/types.py
@@ -77,6 +77,6 @@ class DownloadOptions(TypedDict, total=False):
 
 FileOptions = TypedDict(
     "FileOptions",
-    {"cache-control": str, "content-type": str, "x-upsert": str},
+    {"cache-control": str, "content-type": str, "x-upsert": str, "upsert": str},
     total=False,
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is to address issue https://github.com/supabase-community/supabase-py/issues/693.  Documentation said we could use the upsert option, but user would have to specify x-upsert.  

I also updated pre-commit hooks as the version of autoflake is old enough to still require distutils which no longer exists in python 3.12.  

## What is the current behavior?
Old behavior code:
```
with open(filepath, 'rb') as f:
  supabase.storage.from_("bucket_name").update(file=f, path=path_on_supastorage, file_options={"cache-control": "3600", "upsert": "true"})
```
would not pass along the upsert option to server side.

New behavior:
```
with open(filepath, 'rb') as f:
  supabase.storage.from_("bucket_name").update(file=f, path=path_on_supastorage, file_options={"cache-control": "3600", "upsert": "true"})
```
Is passed along as x-upsert header option.

Please link any relevant issues here.
https://github.com/supabase-community/supabase-py/issues/693

## What is the new behavior?
See above

Feel free to include screenshots if it includes visual changes.

## Additional context
This addresses the client side operation.  

Add any other context or screenshots.
