### PR TITLE
fix: handle json decode error when there's no json response (e.g. on 403)

### DIFF
--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -43,11 +43,16 @@ class AsyncBucketActionsMixin:
             method, url, headers=headers or {}, json=json, files=files, **kwargs
         )
         try:
+            response = self._client.request(
+                method, url, headers=headers or {}, json=json, files=files, **kwargs
+            )
             response.raise_for_status()
         except HTTPError:
-            raise StorageException(
-                {**response.json(), "statusCode": response.status_code}
-            )
+            try:
+                resp = response.json()
+                raise StorageException({**resp, "statusCode": response.status_code})
+            except JSONDecodeError:
+                raise StorageException({"statusCode": response.status_code})
 
         return response
 

--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -39,11 +39,8 @@ class AsyncBucketActionsMixin:
         files: Optional[Any] = None,
         **kwargs: Any,
     ) -> Response:
-        response = await self._client.request(
-            method, url, headers=headers or {}, json=json, files=files, **kwargs
-        )
         try:
-            response = self._client.request(
+            response = await self._client.request(
                 method, url, headers=headers or {}, json=json, files=files, **kwargs
             )
             response.raise_for_status()

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -43,11 +43,16 @@ class SyncBucketActionsMixin:
             method, url, headers=headers or {}, json=json, files=files, **kwargs
         )
         try:
+            response = self._client.request(
+                method, url, headers=headers or {}, json=json, files=files, **kwargs
+            )
             response.raise_for_status()
         except HTTPError:
-            raise StorageException(
-                {**response.json(), "statusCode": response.status_code}
-            )
+            try:
+                resp = response.json()
+                raise StorageException({**resp, "statusCode": response.status_code})
+            except JSONDecodeError:
+                raise StorageException({"statusCode": response.status_code})
 
         return response
 

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -39,9 +39,6 @@ class SyncBucketActionsMixin:
         files: Optional[Any] = None,
         **kwargs: Any,
     ) -> Response:
-        response = self._client.request(
-            method, url, headers=headers or {}, json=json, files=files, **kwargs
-        )
         try:
             response = self._client.request(
                 method, url, headers=headers or {}, json=json, files=files, **kwargs


### PR DESCRIPTION
## What kind of change does this PR introduce?

Seeks to fix https://github.com/supabase-community/supabase-py/issues/721 

We should probably add better error handling at some point - went with a minimal fix for now